### PR TITLE
CI: Use the latest NodeJS on Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: false
 language: node_js
 node_js:
-- '5'
+- '6'
 - '4'
 before_install:
 - npm i -g npm


### PR DESCRIPTION
> Node.js v5 will continue to be supported for the next two months in order to give developers currently using v5 time to transition to Node.js v6. - https://nodejs.org/en/blog/release/v6.0.0/
