### PR TITLE
fix: Update styleistic-issues `one-var` rule:

### DIFF
--- a/lib/configs/rules/stylistic-issues.js
+++ b/lib/configs/rules/stylistic-issues.js
@@ -106,7 +106,7 @@ module.exports = {
 	// Require or disallow padding inside curly braces
 	'object-curly-spacing': 'off',
 	// Allow or disallow one variable declaration per function
-	'one-var': ['warn', 'never'],
+	'one-var': ['error', 'always'],
 	// Require or disallow an newline around variable declarations
 	'one-var-declaration-per-line': ['warn', 'initializations'],
 	// Require assignment operator shorthand where possible or prohibit it entirely


### PR DESCRIPTION
• See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#declaring-variables-with-var
• See JSHint 2.5 deprecated its `onevar` option, see https://core.trac.wordpress.org/ticket/28236
