### PR TITLE
fix: Update possible-errors `comma-dangle` rule:

### DIFF
--- a/lib/configs/rules/possible-errors.js
+++ b/lib/configs/rules/possible-errors.js
@@ -2,7 +2,7 @@
 
 module.exports = {
 	// Disallow or enforce trailing commas
-	'comma-dangle': ['warn', 'always-multiline'],
+	'comma-dangle': ['error', 'never'],
 	// Disallow assignment in conditional expressions
 	'no-cond-assign': 'error',
 	// Disallow use of console


### PR DESCRIPTION
• Disallow trailing commas
• See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#objects
• See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#arrays-and-function-calls
• See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#examples-of-good-spacing
• See https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#underscore-js-collection-functions
