### PR TITLE
chore: Don't explicitly install the latest NPM

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
   directories:
     - node_modules
 before_install:
-- npm i -g npm
 - npm update
 - npm prune
 after_success: npm run coveralls

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
   ],
   "dependencies": {
     "eslint-plugin-ava": "^2.4.0",
-    "eslint-plugin-backbone": "^2.0.1",
+    "eslint-plugin-backbone": "git://github.com/nerfologist/eslint-plugin-backbone.git#ac8577734dd8b908745581d0bc22cb2dd9875dec",
     "eslint-plugin-i18n": "^1.0.1",
     "eslint-plugin-jsdoc": "^2.3.1",
     "eslint-plugin-node": "^1.4.0",


### PR DESCRIPTION
Running `npm i -g npm` on NodeJS 4.x.x LTS branch will install NPM 3.x.c _stable_, by not explicitly installing it NVM should handle this and install the NPM 2.x.x LTS release
