### PR TITLE
Add `one-var` and `no-trailing-spaces` rules

### DIFF
--- a/lib/configs/rules/jshint.js
+++ b/lib/configs/rules/jshint.js
@@ -1,4 +1,4 @@
-// Imported from WordPress .jshinrc using https://github.com/brenolf/polyjuice
+// Imported from WordPress .jshintrc using https://github.com/brenolf/polyjuice
 
 module.exports = {
 	// Specify curly brace conventions for all control statements
@@ -13,12 +13,16 @@ module.exports = {
 	'no-eq-null': 'error',
 	// Disallow irregular whitespace outside of strings and comments
 	'no-irregular-whitespace': 'error',
+	// Disallow trailing whitespace at the end of lines
+	'no-trailing-spaces': 'error',
 	// Disallow usage of expressions in statement position
 	'no-unused-expressions': 'error',
 	// Disallow use of undeclared variables unless mentioned in a /*global */ block
 	'no-undef': 'error',
 	// Disallow declaration of variables that are not used in the code
 	'no-unused-vars': 'error',
+	// Enforce variables to be declared either together or separately in functions
+	'one-var': ['error', 'always'],
 	// Specify whether backticks, double or single quotes should be used
 	'quotes': ['error', 'single'],
 	// Require immediate function invocation to be wrapped in parentheses


### PR DESCRIPTION
Add the ESLint rules for the deprecated JSHint `onevar`, and `trailing` rules with their ESLint equivalent rules `one-var` and `no-trailing-spaces` respectively, see [#WP28236](https://core.trac.wordpress.org/ticket/28236)