### PR TITLE
chore: Switch to minor `~` for semver modules in `package.json`

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,22 +41,22 @@
     "wordpress"
   ],
   "dependencies": {
-    "eslint-plugin-ava": "^3.1.1",
-    "eslint-plugin-backbone": "^2.0.2",
-    "eslint-plugin-i18n": "^1.1.0",
-    "eslint-plugin-jsdoc": "^2.3.1",
-    "eslint-plugin-node": "^2.1.3",
-    "eslint-plugin-qunit": "^2.2.0",
-    "eslint-plugin-wpcalypso": "^3.0.2",
-    "merge": "^1.2.0"
+    "eslint-plugin-ava": "~3.1.1",
+    "eslint-plugin-backbone": "~2.0.2",
+    "eslint-plugin-i18n": "~1.1.0",
+    "eslint-plugin-jsdoc": "~2.3.1",
+    "eslint-plugin-node": "~2.1.3",
+    "eslint-plugin-qunit": "~2.2.0",
+    "eslint-plugin-wpcalypso": "~3.0.2",
+    "merge": "~1.2.0"
   },
   "devDependencies": {
-    "ava": "^0.19.1",
-    "coveralls": "^2.11.13",
-    "eslint": "^3.8.1",
-    "is-plain-obj": "^1.0.0",
-    "nyc": "^10.3.0",
-    "xo": "^0.16.0"
+    "ava": "~0.19.1",
+    "coveralls": "~2.11.13",
+    "eslint": "~3.8.1",
+    "is-plain-obj": "~1.0.0",
+    "nyc": "~10.3.0",
+    "xo": "~0.16.0"
   },
   "peerDependencies": {
     "eslint": ">=2.9.0"


### PR DESCRIPTION
Fixes #58