### PR TITLE
chore: Update `coveralls` to `v2.13.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
   },
   "devDependencies": {
     "ava": "~0.19.1",
-    "coveralls": "~2.11.13",
+    "coveralls": "~2.13.1",
     "eslint": "~3.8.1",
     "is-plain-obj": "~1.0.0",
     "nyc": "~10.3.0",


### PR DESCRIPTION
https://github.com/nickmerwin/node-coveralls/compare/2.11.13...2.13.1 (master)