### PR TITLE
Add rule: array-function-spacing

### DIFF
--- a/docs/rules/array-function-spacing.md
+++ b/docs/rules/array-function-spacing.md
@@ -43,6 +43,9 @@ The following patterns are not warnings:
 ```js
 ( function( wp ) {
 	wp.foo = foo( 'bar', {});
+	wp.baz(function() {
+		console.log( 'Done' );
+	});
 } )( window.wp = window.wp || {} );
 foo(function() {});
 foo(function() {}, 1 );

--- a/docs/rules/array-function-spacing.md
+++ b/docs/rules/array-function-spacing.md
@@ -41,9 +41,9 @@ foo[key ];
 The following patterns are not warnings:
 
 ```js
-(function( wp ) {
+( function( wp ) {
 	wp.foo = foo( 'bar', {});
-})( window.wp = window.wp || {} );
+} )( window.wp = window.wp || {} );
 foo(function() {});
 foo(function() {}, 1 );
 foo( 1, function() {});

--- a/docs/rules/array-function-spacing.md
+++ b/docs/rules/array-function-spacing.md
@@ -1,0 +1,68 @@
+# Enforce whitespace exceptions for array keys and function arguments
+
+For consistency with PHP standards, do not include a space around string literals or integers used as key values in array notation.
+
+Functions with a callback, object, or array as first or last argument should omit space respectively before or after the argument.
+
+## Rule Details
+
+The following patterns are considered warnings:
+
+```js
+foo( function() {} );
+foo( function() {});
+foo(function() {} );
+foo( () => {} );
+foo( () => {});
+foo(() => {} );
+foo( {} );
+foo( {});
+foo({} );
+foo( [] );
+foo( []);
+foo([] );
+foo(1);
+foo( 1);
+foo(1 );
+foo[ 1 ];
+foo[ 1];
+foo[1 ];
+foo[ 'bar' ];
+foo[ 'bar'];
+foo['bar' ];
+foo[ `bar` ];
+foo[ `bar`];
+foo[`bar` ];
+foo[key];
+foo[ key];
+foo[key ];
+```
+
+The following patterns are not warnings:
+
+```js
+(function( wp ) {
+	wp.foo = foo( 'bar', {});
+})( window.wp = window.wp || {} );
+foo(function() {});
+foo(function() {}, 1 );
+foo( 1, function() {});
+foo(() => {});
+foo(() => {}, 1 );
+foo( 1, () => {});
+foo({});
+foo({}, 1 );
+foo( 1, {});
+foo([]);
+foo([], 1 );
+foo( 1, []);
+foo( 1 );
+foo[1];
+foo['bar'];
+foo[`bar`];
+foo[ key ];
+```
+
+## Related Resources
+
+https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#arrays-and-function-calls

--- a/lib/rules/array-function-spacing.js
+++ b/lib/rules/array-function-spacing.js
@@ -1,0 +1,143 @@
+/**
+ * @fileoverview Enforce whitespace exceptions for array keys and function arguments
+ * @author WordPress Contributors
+ * @copyright 2017 WordPress Contributors. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict';
+
+function getFunctionSpacingExceptionType( node ) {
+	switch ( node.type ) {
+		case 'ArrowFunctionExpression':
+		case 'FunctionExpression':
+			return 'function';
+
+		case 'ObjectExpression':
+			return 'object';
+
+		case 'ArrayExpression':
+			return 'array';
+	}
+}
+
+function isFunctionSpacingExceptionType( node ) {
+	return !! getFunctionSpacingExceptionType( node );
+}
+
+function getArraySpacingExceptionType( node ) {
+	switch ( node.property.type ) {
+		case 'TemplateLiteral':
+			return 'string';
+
+		case 'Literal':
+			return typeof node.property.value;
+	}
+}
+
+function isArraySpacingExceptionType( node ) {
+	return !! getArraySpacingExceptionType( node );
+}
+
+function hasWhiteSpaceBetween( start, end ) {
+	return Math.abs( end - start ) > 1;
+}
+
+module.exports = {
+	meta: {
+		docs: {
+			description: 'Enforce whitespace exceptions for array keys and function arguments',
+			category: 'Stylistic Issues'
+		}
+	},
+	create( context ) {
+		return {
+			CallExpression( node ) {
+				if ( ! node.arguments.length ) {
+					return;
+				}
+
+				const first = node.arguments[0];
+				const last = node.arguments[ node.arguments.length - 1 ];
+
+				if ( isFunctionSpacingExceptionType( first ) ) {
+					if ( hasWhiteSpaceBetween( first.start, node.callee.end ) ) {
+						context.report( {
+							node: first,
+							message: 'There should be no whitespace before first function argument of type {{type}}',
+							data: {
+								type: getFunctionSpacingExceptionType( first )
+							}
+						} );
+					}
+				} else {
+					if ( ! hasWhiteSpaceBetween( first.start, node.callee.end ) ) {
+						context.report( {
+							node: first,
+							message: 'There should be whitespace before first function argument'
+						} );
+					}
+				}
+
+				if ( isFunctionSpacingExceptionType( last ) ) {
+					if ( hasWhiteSpaceBetween( last.end, node.end ) ) {
+						context.report( {
+							node: last,
+							message: 'There should be no whitespace after last function argument of type {{type}}',
+							data: {
+								type: getFunctionSpacingExceptionType( last )
+							}
+						} );
+					}
+				} else {
+					if ( ! hasWhiteSpaceBetween( last.end, node.end ) ) {
+						context.report( {
+							node: last,
+							message: 'There should be whitespace after last function argument'
+						} );
+					}
+				}
+			},
+			MemberExpression( node ) {
+				if ( ! node.computed ) {
+					return;
+				}
+
+				if ( isArraySpacingExceptionType( node ) ) {
+					if ( hasWhiteSpaceBetween( node.object.end, node.property.start ) ) {
+						context.report( {
+							node: node,
+							message: 'There should be no whitespace before array {{type}} property',
+							data: {
+								type: getArraySpacingExceptionType( node )
+							}
+						} );
+					}
+
+					if ( hasWhiteSpaceBetween( node.property.end, node.end ) ) {
+						context.report( {
+							node: node,
+							message: 'There should be no whitespace after array {{type}} property',
+							data: {
+								type: getArraySpacingExceptionType( node )
+							}
+						} );
+					}
+				} else {
+					if ( ! hasWhiteSpaceBetween( node.object.end, node.property.start ) ) {
+						context.report( {
+							node: node,
+							message: 'There should be whitespace before array property'
+						} );
+					}
+
+					if ( ! hasWhiteSpaceBetween( node.property.end, node.end ) ) {
+						context.report( {
+							node: node,
+							message: 'There should be whitespace after array property'
+						} );
+					}
+				}
+			}
+		};
+	}
+};

--- a/test/rules/array-function-spacing.js
+++ b/test/rules/array-function-spacing.js
@@ -20,7 +20,7 @@ const rule = require( '../../lib/rules/array-function-spacing' ),
 ( new RuleTester( { env: { es6: true } } ) ).run( 'array-function-spacing', rule, {
 	valid: [
 		{
-			code: '( function( wp ) {\n	wp.foo = foo( \'bar\', {});\n} )( window.wp = window.wp || {} );'
+			code: '( function( wp ) {\n	wp.foo = foo( \'bar\', {});\n	wp.baz(function() {\n		console.log( \'Done\' );\n	});\n} )( window.wp = window.wp || {} );'
 		},
 		{
 			code: 'foo(function() {});'

--- a/test/rules/array-function-spacing.js
+++ b/test/rules/array-function-spacing.js
@@ -20,7 +20,7 @@ const rule = require( '../../lib/rules/array-function-spacing' ),
 ( new RuleTester( { env: { es6: true } } ) ).run( 'array-function-spacing', rule, {
 	valid: [
 		{
-			code: '(function( wp ) {\n	wp.foo = foo( \'bar\', {});\n})( window.wp = window.wp || {} );'
+			code: '( function( wp ) {\n	wp.foo = foo( \'bar\', {});\n} )( window.wp = window.wp || {} );'
 		},
 		{
 			code: 'foo(function() {});'

--- a/test/rules/array-function-spacing.js
+++ b/test/rules/array-function-spacing.js
@@ -1,0 +1,251 @@
+/**
+ * @fileoverview Enforce whitespace exceptions for array keys and function arguments
+ * @author WordPress Contributors
+ * @copyright 2017 WordPress Contributors. All rights reserved.
+ * See LICENSE file in root directory for full license.
+ */
+'use strict';
+
+//------------------------------------------------------------------------------
+// Requirements
+//------------------------------------------------------------------------------
+
+const rule = require( '../../lib/rules/array-function-spacing' ),
+	RuleTester = require( 'eslint' ).RuleTester;
+
+//------------------------------------------------------------------------------
+// Tests
+//------------------------------------------------------------------------------
+
+( new RuleTester( { env: { es6: true } } ) ).run( 'array-function-spacing', rule, {
+	valid: [
+		{
+			code: '(function( wp ) {\n	wp.foo = foo( \'bar\', {});\n})( window.wp = window.wp || {} );'
+		},
+		{
+			code: 'foo(function() {});'
+		},
+		{
+			code: 'foo(function() {}, 1 );'
+		},
+		{
+			code: 'foo( 1, function() {});'
+		},
+		{
+			code: 'foo(() => {});'
+		},
+		{
+			code: 'foo(() => {}, 1 );'
+		},
+		{
+			code: 'foo( 1, () => {});'
+		},
+		{
+			code: 'foo({});'
+		},
+		{
+			code: 'foo({}, 1 );'
+		},
+		{
+			code: 'foo( 1, {});'
+		},
+		{
+			code: 'foo([]);'
+		},
+		{
+			code: 'foo([], 1 );'
+		},
+		{
+			code: 'foo( 1, []);'
+		},
+		{
+			code: 'foo( 1 );'
+		},
+		{
+			code: 'foo[1];'
+		},
+		{
+			code: 'foo[\'bar\'];'
+		},
+		{
+			code: 'foo[`bar`];'
+		},
+		{
+			code: 'foo[ key ];'
+		}
+	],
+
+	invalid: [
+		{
+			code: 'foo( function() {} );',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type function' },
+				{ message: 'There should be no whitespace after last function argument of type function' }
+			]
+		},
+		{
+			code: 'foo( function() {});',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type function' }
+			]
+		},
+		{
+			code: 'foo(function() {} );',
+			errors: [
+				{ message: 'There should be no whitespace after last function argument of type function' }
+			]
+		},
+		{
+			code: 'foo( () => {} );',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type function' },
+				{ message: 'There should be no whitespace after last function argument of type function' }
+			]
+		},
+		{
+			code: 'foo( () => {});',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type function' }
+			]
+		},
+		{
+			code: 'foo(() => {} );',
+			errors: [
+				{ message: 'There should be no whitespace after last function argument of type function' }
+			]
+		},
+		{
+			code: 'foo( {} );',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type object' },
+				{ message: 'There should be no whitespace after last function argument of type object' }
+			]
+		},
+		{
+			code: 'foo( {});',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type object' }
+			]
+		},
+		{
+			code: 'foo({} );',
+			errors: [
+				{ message: 'There should be no whitespace after last function argument of type object' }
+			]
+		},
+		{
+			code: 'foo( [] );',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type array' },
+				{ message: 'There should be no whitespace after last function argument of type array' }
+			]
+		},
+		{
+			code: 'foo( []);',
+			errors: [
+				{ message: 'There should be no whitespace before first function argument of type array' }
+			]
+		},
+		{
+			code: 'foo([] );',
+			errors: [
+				{ message: 'There should be no whitespace after last function argument of type array' }
+			]
+		},
+		{
+			code: 'foo(1);',
+			errors: [
+				{ message: 'There should be whitespace before first function argument' },
+				{ message: 'There should be whitespace after last function argument' }
+			]
+		},
+		{
+			code: 'foo( 1);',
+			errors: [
+				{ message: 'There should be whitespace after last function argument' }
+			]
+		},
+		{
+			code: 'foo(1 );',
+			errors: [
+				{ message: 'There should be whitespace before first function argument' }
+			]
+		},
+		{
+			code: 'foo[ 1 ];',
+			errors: [
+				{ message: 'There should be no whitespace before array number property' },
+				{ message: 'There should be no whitespace after array number property' }
+			]
+		},
+		{
+			code: 'foo[ 1];',
+			errors: [
+				{ message: 'There should be no whitespace before array number property' }
+			]
+		},
+		{
+			code: 'foo[1 ];',
+			errors: [
+				{ message: 'There should be no whitespace after array number property' }
+			]
+		},
+		{
+			code: 'foo[ \'bar\' ];',
+			errors: [
+				{ message: 'There should be no whitespace before array string property' },
+				{ message: 'There should be no whitespace after array string property' }
+			]
+		},
+		{
+			code: 'foo[ \'bar\'];',
+			errors: [
+				{ message: 'There should be no whitespace before array string property' }
+			]
+		},
+		{
+			code: 'foo[\'bar\' ];',
+			errors: [
+				{ message: 'There should be no whitespace after array string property' }
+			]
+		},
+		{
+			code: 'foo[ `bar` ];',
+			errors: [
+				{ message: 'There should be no whitespace before array string property' },
+				{ message: 'There should be no whitespace after array string property' }
+			]
+		},
+		{
+			code: 'foo[ `bar`];',
+			errors: [
+				{ message: 'There should be no whitespace before array string property' }
+			]
+		},
+		{
+			code: 'foo[`bar` ];',
+			errors: [
+				{ message: 'There should be no whitespace after array string property' }
+			]
+		},
+		{
+			code: 'foo[key];',
+			errors: [
+				{ message: 'There should be whitespace before array property' },
+				{ message: 'There should be whitespace after array property' }
+			]
+		},
+		{
+			code: 'foo[ key];',
+			errors: [
+				{ message: 'There should be whitespace after array property' }
+			]
+		},
+		{
+			code: 'foo[key ];',
+			errors: [
+				{ message: 'There should be whitespace before array property' }
+			]
+		}
+	]
+} );


### PR DESCRIPTION
This pull request seeks to add a new rule to enforce whitespace exceptions on function and array arguments and properties.

__See:__ https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#arrays-and-function-calls

__Note:__ The [base `space-in-parens` rule](http://eslint.org/docs/rules/space-in-parens#exceptions) allows exceptions for objects and arrays, which is already assigned in this project's configurations. The rule introduced here also checks functions as an exception.

__Testing:__ I found the project's `npm test` flags many lint errors incorrectly. To run the new rule's tests specifically, execute `node test/rules/array-function-spacing.js` and verify no thrown errors.

__Future Tasks:__ Add [fixer](http://eslint.org/docs/developer-guide/working-with-rules-new#applying-fixes).

># Enforce whitespace exceptions for array keys and function arguments
>
>For consistency with PHP standards, do not include a space around string literals or integers used as key values in array notation.
>
>Functions with a callback, object, or array as first or last argument should omit space respectively before or after the argument.
>
>## Rule Details
>
>The following patterns are considered warnings:
>
>```js
>foo( function() {} );
>foo( function() {});
>foo(function() {} );
>foo( () => {} );
>foo( () => {});
>foo(() => {} );
>foo( {} );
>foo( {});
>foo({} );
>foo( [] );
>foo( []);
>foo([] );
>foo(1);
>foo( 1);
>foo(1 );
>foo[ 1 ];
>foo[ 1];
>foo[1 ];
>foo[ 'bar' ];
>foo[ 'bar'];
>foo['bar' ];
>foo[ `bar` ];
>foo[ `bar`];
>foo[`bar` ];
>foo[key];
>foo[ key];
>foo[key ];
>```
>
>The following patterns are not warnings:
>
>```js
>( function( wp ) {
>	wp.foo = foo( 'bar', {});
>	wp.baz(function() {
>		console.log( 'Done' );
>	});
>} )( window.wp = window.wp || {} );
>foo(function() {});
>foo(function() {}, 1 );
>foo( 1, function() {});
>foo(() => {});
>foo(() => {}, 1 );
>foo( 1, () => {});
>foo({});
>foo({}, 1 );
>foo( 1, {});
>foo([]);
>foo([], 1 );
>foo( 1, []);
>foo( 1 );
>foo[1];
>foo['bar'];
>foo[`bar`];
>foo[ key ];
>```
>
>## Related Resources
>
>https://make.wordpress.org/core/handbook/best-practices/coding-standards/javascript/#arrays-and-function-calls

cc @afercia