### PR TITLE
Fix: Moved `comma-dangle` rule from `possible-errors` rule set to `stylistic-issues` rule set.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# HEAD
+
+* Fix: Moved `comma-dangle` rule from `possible-errors` rule set to `stylistic-issues` rule set.
+
 # 0.1.0
 
 * Publish to npmjs.com

--- a/lib/configs/rules/possible-errors.js
+++ b/lib/configs/rules/possible-errors.js
@@ -1,8 +1,6 @@
 // see http://eslint.org/docs/rules/#possible-errors
 
 module.exports = {
-	// Disallow or enforce trailing commas
-	'comma-dangle': ['error', 'never'],
 	// Disallow assignment in conditional expressions
 	'no-cond-assign': 'error',
 	// Disallow use of console

--- a/lib/configs/rules/stylistic-issues.js
+++ b/lib/configs/rules/stylistic-issues.js
@@ -13,6 +13,8 @@ module.exports = {
 	'camelcase': ['warn', {
 		properties: 'always'
 	}],
+	// Disallow or enforce trailing commas
+	'comma-dangle': ['error', 'never'],
 	// Enforce spacing before and after comma
 	'comma-spacing': ['warn', {
 		before: false,


### PR DESCRIPTION
• `comma-dangle` is a [stylistic rule](http://eslint.org/docs/rules/#stylistic-issues) 

See #79