### PR TITLE
Chore: Drop Node.js version 7.x from Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 language: node_js
 node_js:
 - '8'
-- '7'
 - '6'
 cache:
   directories:


### PR DESCRIPTION
Node.js version 8.x is the latest "current" branch release and supersedes the version 7.x branch