### PR TITLE
Prefer `@return` over `@returns`

### DIFF
--- a/lib/configs/rules/jsdoc.js
+++ b/lib/configs/rules/jsdoc.js
@@ -8,7 +8,11 @@ module.exports = {
 		},
 	} ],
 	// Ensure JSDoc comments are valid
-	'valid-jsdoc': 'error',
+	'valid-jsdoc': [ 'error', {
+		prefer: {
+			'returns': 'return',
+		},
+	} ],
 	// Ensures that parameter names in JSDoc match those in the function declaration.
 	'jsdoc/check-param-names': 'warn',
 	// Reports invalid block tag names.


### PR DESCRIPTION
We've decided in the JS core chat to prefer `@return` over `@returns`.