### PR TITLE
Assign preferred JSDoc tags and types

### DIFF
--- a/__tests__/wpcs/__snapshots__/jsdocs-test.js.snap
+++ b/__tests__/wpcs/__snapshots__/jsdocs-test.js.snap
@@ -31,15 +31,45 @@ error: Missing JSDoc @return for function (valid-jsdoc) at __tests__/wpcs/fixtur
   30 |  * @param {number} foo Param desc capital to start, period to end.
 
 
-error: Missing JSDoc @return for function (valid-jsdoc) at __tests__/wpcs/fixtures/jsdocs.js:37:1:
+warning: Invalid JSDoc tag (preference). Replace \\"arg\\" JSDoc tag with \\"param\\" (jsdoc/check-tag-names) at __tests__/wpcs/fixtures/jsdocs.js:37:1:
   35 | }
   36 | 
 > 37 | /**
      | ^
-  38 |  * JSDoc test missing @returns the sum of foo and bar.
+  38 |  * JSDoc test @arg.
   39 |  *
-  40 |  * @param {number} foo Param desc capital to start, period to end.
+  40 |  * @arg {number} foo Param desc capital to start, period to end.
 
 
-3 errors and 1 warning found."
+error: Use @param instead (valid-jsdoc) at __tests__/wpcs/fixtures/jsdocs.js:37:1:
+  35 | }
+  36 | 
+> 37 | /**
+     | ^
+  38 |  * JSDoc test @arg.
+  39 |  *
+  40 |  * @arg {number} foo Param desc capital to start, period to end.
+
+
+warning: Invalid JSDoc tag (preference). Replace \\"argument\\" JSDoc tag with \\"param\\" (jsdoc/check-tag-names) at __tests__/wpcs/fixtures/jsdocs.js:48:1:
+  46 | }
+  47 | 
+> 48 | /**
+     | ^
+  49 |  * JSDoc test @argument the sum of foo and bar.
+  50 |  *
+  51 |  * @argument {number} bar Param desc capital to start, period to end.
+
+
+error: Use @param instead (valid-jsdoc) at __tests__/wpcs/fixtures/jsdocs.js:48:1:
+  46 | }
+  47 | 
+> 48 | /**
+     | ^
+  49 |  * JSDoc test @argument the sum of foo and bar.
+  50 |  *
+  51 |  * @argument {number} bar Param desc capital to start, period to end.
+
+
+4 errors and 3 warnings found."
 `;

--- a/__tests__/wpcs/fixtures/jsdocs.js
+++ b/__tests__/wpcs/fixtures/jsdocs.js
@@ -35,12 +35,36 @@ function missingReturn(foo, bar) {
 }
 
 /**
- * JSDoc test missing @returns the sum of foo and bar.
+ * JSDoc test @arg.
+ *
+ * @arg {number} foo Param desc capital to start, period to end.
+ *
+ * @return {number} Sum of foo and bar, uses invalid @return.
+ */
+function usesArg(foo) {
+	return foo;
+}
+
+/**
+ * JSDoc test @argument the sum of foo and bar.
+ *
+ * @argument {number} bar Param desc capital to start, period to end.
+ *
+ * @return {number} Sum of foo and bar, uses invalid @return.
+ */
+function usesArgument(bar) {
+	return bar;
+}
+
+/**
+ * JSDoc test @extends the sum of foo and bar.
  *
  * @param {number} foo Param desc capital to start, period to end.
  * @param {number} bar Param desc capital to start, period to end.
+ *
+ * @return {number} Sum of foo and bar, uses invalid @return.
  */
-function missingReturns( foo, bar ) {
+function usesExtends(foo, bar) {
 	return foo + bar;
 }
 

--- a/__tests__/wpcs/jsdocs-test.js
+++ b/__tests__/wpcs/jsdocs-test.js
@@ -24,8 +24,8 @@ describe( 'JSDoc config tests', () => {
 
 		expect( report.results.length ).toBe( 1 );
 		expect( report.errored ).toBeFalsy();
-		expect( report.errorCount ).toBe( 3 );
-		expect( report.warningCount ).toBe( 1 );
+		expect( report.errorCount ).toBe( 4 );
+		expect( report.warningCount ).toBe( 3 );
 		expect( report.fixableErrorCount ).toBe( 0 );
 		expect( report.fixableWarningCount ).toBe( 0 );
 	});

--- a/lib/configs/rules/jsdoc.js
+++ b/lib/configs/rules/jsdoc.js
@@ -47,7 +47,7 @@ module.exports = {
 	// Requires a hyphen before the @param description.
 	'jsdoc/require-hyphen-before-param-description': 'off',
 	// Requires that all function parameters are documented.
-	'jsdoc/require-param': 'warn',
+	'jsdoc/require-param': 'off',
 	// Requires that @param tag has description value.
 	'jsdoc/require-param-description': 'warn',
 	// Requires that @param tag has type value.

--- a/lib/configs/rules/jsdoc.js
+++ b/lib/configs/rules/jsdoc.js
@@ -10,8 +10,27 @@ module.exports = {
 	// Ensure JSDoc comments are valid
 	'valid-jsdoc': [ 'error', {
 		prefer: {
+			arg: 'param',
+			argument: 'param',
+			extends: 'augments',
 			returns: 'return',
 		},
+		preferType: {
+			array: 'Array',
+			bool: 'boolean',
+			Boolean: 'boolean',
+			float: 'number',
+			Float: 'number',
+			int: 'number',
+			integer: 'number',
+			Integer: 'number',
+			Number: 'number',
+			object: 'Object',
+			String: 'string',
+			Void: 'void',
+		},
+		requireParamDescription: false,
+		requireReturn: false,
 	} ],
 	// Ensures that parameter names in JSDoc match those in the function declaration.
 	'jsdoc/check-param-names': 'warn',


### PR DESCRIPTION
See also: https://github.com/WordPress/gutenberg/pull/4785 https://github.com/WordPress/gutenberg/pull/4853