### PR TITLE
chore: bump minimum Node.js required version to `8.9.3`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 language: node_js
 node_js:
   - '8'
-  - '6'
+  - '9'
 cache:
   directories:
     - $HOME/.npm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@
 * chore: add `package-lock.json` to `.gitignore`.
 * chore: add Jest configuration and scripts to `package.json`.
 * chore: add Jest to `env` in `.eslintrc.json`.
-* chore: Bump minimum Node.js required version to `6.9.1`.
+* chore: Bump minimum Node.js required version to `8.9.3`.
 * chore: install the latest release of npm for all Travis CI jobs.
 * chore: move ESLint config from `package.json` to standalone `.eslintrc.json` file.
 * chore: remove `.gitkeep` placeholder file.

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
 		"url": "https://netweb.com.au"
 	},
 	"engines": {
-		"node": ">=6.9.1"
+		"node": ">=8.9.3"
 	},
 	"scripts": {
 		"dry-release": "npmpub --dry --verbose",


### PR DESCRIPTION
The minimum Node.js required version should match WordPress Core. 

• https://core.trac.wordpress.org/ticket/35105
• https://core.trac.wordpress.org/changeset/42461