### PR TITLE
feat: update ES6 config per Gutenberg ESLint config

### DIFF
--- a/lib/configs/rules/es6.js
+++ b/lib/configs/rules/es6.js
@@ -8,7 +8,7 @@ module.exports = {
 	// enforce consistent spacing before and after the arrow in arrow functions
 	'arrow-spacing': 'off',
 	// require super() calls in constructors
-	'constructor-super': 'off',
+	'constructor-super': 'error',
 	// enforce consistent spacing around * operators in generator functions
 	'generator-star-spacing': 'off',
 	// disallow reassigning class members
@@ -16,11 +16,11 @@ module.exports = {
 	// disallow arrow functions where they could be confused with comparisons
 	'no-confusing-arrow': 'off',
 	// disallow reassigning `const` variables
-	'no-const-assign': 'off',
+	'no-const-assign': 'error',
 	// disallow duplicate class members
-	'no-dupe-class-members': 'off',
+	'no-dupe-class-members': 'error',
 	// disallow duplicate module imports
-	'no-duplicate-imports': 'off',
+	'no-duplicate-imports': 'error',
 	// disallow `new` operators with the `Symbol` object
 	'no-new-symbol': 'off',
 	// disallow specified modules when loaded by `import`
@@ -28,19 +28,19 @@ module.exports = {
 	// disallow `this`/`super` before calling `super()` in constructors
 	'no-this-before-super': 'off',
 	// disallow unnecessary computed property keys in object literals
-	'no-useless-computed-key': 'off',
+	'no-useless-computed-key': 'error',
 	// disallow unnecessary constructors
-	'no-useless-constructor': 'off',
+	'no-useless-constructor': 'error',
 	// disallow renaming import, export, and destructured assignments to the same name
 	'no-useless-rename': 'off',
 	// require `let` or `const` instead of `var`
-	'no-var': 'off',
+	'no-var': 'error',
 	// require or disallow method and property shorthand syntax for object literals
 	'object-shorthand': 'off',
 	// require arrow functions as callbacks
 	'prefer-arrow-callback': 'off',
 	// require `const` declarations for variables that are never reassigned after declared
-	'prefer-const': 'off',
+	'prefer-const': 'error',
 	// require destructuring from arrays and/or objects
 	'prefer-destructuring': 'off',
 	// disallow `parseInt()` and `Number.parseInt()` in favor of binary, octal, and hexadecimal literals
@@ -60,7 +60,7 @@ module.exports = {
 	// require symbol descriptions
 	'symbol-description': 'off',
 	// require or disallow spacing around embedded expressions of template strings
-	'template-curly-spacing': 'off',
+	'template-curly-spacing': [ 'error', 'always' ],
 	// require or disallow spacing around the `*` in `yield*` expressions
 	'yield-star-spacing': 'off',
 };


### PR DESCRIPTION
This PR migrates ESLint ES6 rules out of Gutenberg and into the `eslint-plugin-wordpress` package and the `wordpress/es6` configuration.

Please see the companion pull request for Gutenberg linked below for further reference

cc @gziolo