### PR TITLE
fix: remove `es6` environment from `node` config

### DIFF
--- a/lib/configs/node.js
+++ b/lib/configs/node.js
@@ -1,6 +1,5 @@
 module.exports = {
 	env: {
-		es6: true,
 		node: true,
 	},
 


### PR DESCRIPTION
Fixes #144